### PR TITLE
Use Discord.py bot command extension framework

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.0/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT="3.9"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.0/containers/python-3
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+			"VARIANT": "3.9",
+			// Options
+			"NODE_VERSION": "none"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=yourkey

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .direnv/
 __pycache__/
 .DS_Store
+.env

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "pip install",
+            "type": "shell",
+            "command": "pip install -r requirements.txt"
+        }
+    ]
+}

--- a/bot.py
+++ b/bot.py
@@ -1,17 +1,22 @@
-import discord
 from collections import defaultdict
 import random
 import os
+import sys
+
+import discord
+
 
 def command_from_message(content):
     try:
         pos = content.find('>')
-        return content if pos == -1 else content[pos+2:]
+        return content if pos == -1 else content[pos + 2 :]
     except:
         return None
 
+
 def lower(msg):
     return msg.lower().strip('#?!., \n\r').replace("'", '')
+
 
 class Game:
     def __init__(self):
@@ -55,7 +60,8 @@ class Game:
         return msgs
 
     def submission(self, author, text):
-        if author not in self.players: return [':🚫']
+        if author not in self.players:
+            return [':🚫']
 
         round = self.get_round()
         round[author] = text
@@ -73,13 +79,14 @@ class Game:
         random.shuffle(self.order)
         round = self.get_round()
         for i, x in enumerate(self.order):
-            msg += '{}. {}\n'.format(i+1, round[self.players[x]])
+            msg += '{}. {}\n'.format(i + 1, round[self.players[x]])
         msg += '\nHit me with a DM or mention with your guess number!'
         msgs.append(msg)
         return msgs
 
     def guess(self, player, guess):
-        if player not in self.players or player == self.get_truther(): return [':🚫']
+        if player not in self.players or player == self.get_truther():
+            return [':🚫']
 
         try:
             guess = int(guess)
@@ -96,18 +103,18 @@ class Game:
     def finish_round(self):
         truther = self.get_truther()
         real = self.get_round()[truther]
-        #print('===', truther, real, self.players, self.order)
+        # print('===', truther, real, self.players, self.order)
         msg = "The real answer was '{}'!".format(real)
         real_guess = False
         for player, guess in self.guesses.items():
             owner = self.players[self.order[guess]]
-            #print('===', player, guess+1, owner)
+            # print('===', player, guess+1, owner)
             if owner == truther:
-                msg += "\n* {} correctly guessed {} (+1 for {})".format(player, guess+1, player)
+                msg += "\n* {} correctly guessed {} (+1 for {})".format(player, guess + 1, player)
                 self.scores[player] += 1
                 real_guess = True
             else:
-                msg += "\n* {} guessed {} (+1 to {})".format(player, guess+1, owner)
+                msg += "\n* {} guessed {} (+1 to {})".format(player, guess + 1, owner)
                 self.scores[owner] += 1
         if not real_guess:
             msg += "\n* {} fooled everyone with {}, +1 for them!".format(truther, real)
@@ -123,15 +130,20 @@ class Game:
     def __str__(self):
         status = 'In state "{}" with players {}'.format(self.state, self.players)
         if self.state != 'unstarted':
-            status += '\nIn Round #{}. Submissions from {}, guesses from {}'.format(len(self.rounds), list(self.get_round().keys()), list(self.guesses.keys()))
+            status += '\nIn Round #{}. Submissions from {}, guesses from {}'.format(
+                len(self.rounds), list(self.get_round().keys()), list(self.guesses.keys())
+            )
         return status
+
 
 client = discord.Client()
 game = Game()
 
+
 @client.event
 async def on_ready():
     print('We have logged in as {0.user}'.format(client))
+
 
 @client.event
 async def on_message(message):
@@ -169,9 +181,8 @@ async def on_message(message):
     elif direct and game.instate('awaiting_nextround') and icommand == 'again':
         await handle_response(game.next_round())
 
+
 if __name__ == "__main__":
-    import os
-    import sys
     if os.getenv('DISCORD_TOKEN'):
         token = os.getenv('DISCORD_TOKEN')
     else:

--- a/bot.py
+++ b/bot.py
@@ -30,7 +30,7 @@ class Game:
         player = author
         if player not in self.players:
             self.players.append(player)
-        return [':🐴']
+        return ['🐴']
 
     def get_round(self):
         return self.rounds[-1]
@@ -51,12 +51,12 @@ class Game:
 
     def submission(self, author, text) -> List[str]:
         if author not in self.players:
-            return [':🚫']
+            return ['🚫']
 
         round = self.get_round()
         round[author] = text
         num_submissions = len(round.keys())
-        msgs = [':✅']
+        msgs = ['✅']
         if num_submissions == len(self.players):
             msgs += self.show_submissions()
         return msgs
@@ -76,19 +76,19 @@ class Game:
 
     def guess(self, player, guess):
         if player not in self.players or player == self.get_truther():
-            return [':🚫']
+            return ['🚫']
 
         try:
             guess = int(guess)
         except ValueError:
-            return [':😱']
+            return ['😱']
 
         self.guesses[player] = guess - 1
         msgs = []
         if len(self.guesses) == len(self.players) - 1:
             self.state = 'awaiting_nextround'
             msgs += self.finish_round()
-        return [':✅'] + msgs
+        return ['✅'] + msgs
 
     def finish_round(self):
         truther = self.get_truther()

--- a/tests.py
+++ b/tests.py
@@ -3,8 +3,8 @@ import unittest
 
 from bot import Game
 
-class TestGame(unittest.TestCase):
 
+class TestGame(unittest.TestCase):
     def test_initial_state(self):
         g = Game()
         self.assertTrue(g.instate('unstarted'))
@@ -72,7 +72,7 @@ class TestGame(unittest.TestCase):
         g.submission('fakeandy', 'gokarts')
         g.submission('tater', 'bofa deez nuts')
         msgs = g.submission('roonbaob', 'Chocolate')
-        #print(msgs[1])
+        # print(msgs[1])
 
         msgs = g.guess('nonplayer', '1')
         self.assertEqual(msgs, [':🚫'])
@@ -93,13 +93,12 @@ class TestGame(unittest.TestCase):
         msgs = g.guess('roonbaob', '1')
         self.assertEqual(msgs[0], ':✅')
         self.assertEqual(len(msgs), 2)
-        #print(msgs[1])
+        # print(msgs[1])
         self.assertTrue(g.instate('awaiting_nextround'))
 
         self.assertEqual(len(g.guesses), 2)
         g.next_round()
         self.assertEqual(len(g.guesses), 0)
-
 
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -22,7 +22,7 @@ class TestGame(unittest.TestCase):
 
         self.assertEqual(g.players, [])
         msgs = g.add_player('fakeandy')
-        self.assertEqual(msgs, [':🐴'])
+        self.assertEqual(msgs, ['🐴'])
         self.assertEqual(g.players, ['fakeandy'])
         # Ensure we don't get a dupe
         g.add_player('fakeandy')
@@ -49,15 +49,15 @@ class TestGame(unittest.TestCase):
         self.assertTrue(g.get_truther(), 'roonbaob')
         msgs = g.submission('fakeandy', 'gokarts')
         self.assertTrue(g.instate('awaiting_submissions'))
-        self.assertEqual(msgs, [':✅'])
+        self.assertEqual(msgs, ['✅'])
 
         msgs = g.submission('unaddedplayer', 'fakeout')
         self.assertTrue(g.instate('awaiting_submissions'))
-        self.assertEqual(msgs, [':🚫'])
+        self.assertEqual(msgs, ['🚫'])
 
         msgs = g.submission('roonbaob', 'chocolate')
         self.assertTrue(g.instate('awaiting_guesses'))
-        self.assertEqual(msgs[0], ':✅')
+        self.assertEqual(msgs[0], '✅')
         self.assertEqual(len(msgs), 2)
 
     def test_guesses(self):
@@ -75,23 +75,23 @@ class TestGame(unittest.TestCase):
         # print(msgs[1])
 
         msgs = g.guess('nonplayer', '1')
-        self.assertEqual(msgs, [':🚫'])
+        self.assertEqual(msgs, ['🚫'])
         self.assertTrue(g.instate('awaiting_guesses'))
 
         # Ensure a submitter can't guess.
         self.assertEqual(g.get_truther(), 'fakeandy')
         msgs = g.guess('fakeandy', '1')
-        self.assertEqual(msgs, [':🚫'])
+        self.assertEqual(msgs, ['🚫'])
         self.assertTrue(g.instate('awaiting_guesses'))
 
         # Ensure a non-int is handled gracefully.
         msgs = g.guess('roonbaob', '2x')
-        self.assertEqual(msgs[0], ':😱')
+        self.assertEqual(msgs[0], '😱')
 
         msgs = g.guess('tater', '3')
-        self.assertEqual(msgs, [':✅'])
+        self.assertEqual(msgs, ['✅'])
         msgs = g.guess('roonbaob', '1')
-        self.assertEqual(msgs[0], ':✅')
+        self.assertEqual(msgs[0], '✅')
         self.assertEqual(len(msgs), 2)
         # print(msgs[1])
         self.assertTrue(g.instate('awaiting_nextround'))


### PR DESCRIPTION
Closes #7.

This uses the bot command framework to do a couple things:

* Bot game commands are now a cog. This opens us up to easier make other cogs and organize bot components as cogs (other games or sets of commands as a separate cog).
* Bot commands are now all prefixed as 🐴 (🐴in, 🐴giddyup, etc). This is generally so it is easier to distinguish bot commands vs normal text. They are also grouped under an automatic generated 🐴help command to list them.
* if / else and handler clause replaced with cog commands and checks. Moves our own message handler logic to Discord.py native command framework.
* Add devcontainer for VSCode container development.
* Some minor formatting using `black`. Maybe we can standardize on a formatting style (ie. `"` instead of `'`, etc)?
* Removed `command_from_message` and `lower` (it looked like we didn't need to do those anymore).

Todo:

* Make `is_state` decorator work as a normal check function somehow to be reused in `on_message`?
* Maybe tests using `dpytest`?
* Modify `Game` class to return `boolean` types instead of emoji strings and have the emoji responses in the `GameCog` instead?
* Separate `bot.py` into a `game.py` and `bot.py`?
* Better command prefix (or list of prefixes to support)?

![bitmoji](https://sdk.bitmoji.com/render/panel/e0c8b93f-c246-46e8-9db2-ec0cb01ec9eb-b833cf94-474d-4dce-affc-a58b270d87f9-v1.png?transparent=1&palette=1&width=246)